### PR TITLE
grid and tower placement added

### DIFF
--- a/Defend The Divine/Assets/Prefabs/Tower.prefab
+++ b/Defend The Divine/Assets/Prefabs/Tower.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8974914344815011484
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7982588207619209293}
+  - component: {fileID: 8155601902515693895}
+  m_Layer: 0
+  m_Name: Tower
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7982588207619209293
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8974914344815011484}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5.09, y: 2.76, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8155601902515693895
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8974914344815011484}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 0.050904155, g: 1, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Defend The Divine/Assets/Prefabs/Tower.prefab.meta
+++ b/Defend The Divine/Assets/Prefabs/Tower.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f3a91c6d2f2ee1e4c8bf7b6c2a101adc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Defend The Divine/Assets/Scenes/Main Level.unity
+++ b/Defend The Divine/Assets/Scenes/Main Level.unity
@@ -254,6 +254,7 @@ GameObject:
   m_Component:
   - component: {fileID: 102488505}
   - component: {fileID: 102488506}
+  - component: {fileID: 102488507}
   m_Layer: 0
   m_Name: Square (2)
   m_TagString: Untagged
@@ -270,7 +271,7 @@ Transform:
   m_GameObject: {fileID: 102488504}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: 0.418319, w: 0.9083002}
-  m_LocalPosition: {x: 0.29, y: -1.28, z: -0.049875434}
+  m_LocalPosition: {x: 0.29, y: -1.28, z: 0}
   m_LocalScale: {x: 5.2543454, y: 0.875, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -328,6 +329,52 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &102488507
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 102488504}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &144023205
 GameObject:
   m_ObjectHideFlags: 0
@@ -618,6 +665,7 @@ GameObject:
   m_Component:
   - component: {fileID: 295984896}
   - component: {fileID: 295984897}
+  - component: {fileID: 295984898}
   m_Layer: 0
   m_Name: Square (8)
   m_TagString: Untagged
@@ -634,7 +682,7 @@ Transform:
   m_GameObject: {fileID: 295984895}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: 0.03155765, w: 0.99950194}
-  m_LocalPosition: {x: -1.3, y: -2.19, z: -0.049875434}
+  m_LocalPosition: {x: -1.3, y: -2.19, z: 0}
   m_LocalScale: {x: 0.9845067, y: 0.41251874, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -692,6 +740,52 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &295984898
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 295984895}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &303402848
 GameObject:
   m_ObjectHideFlags: 0
@@ -1168,6 +1262,9 @@ GameObject:
   m_Component:
   - component: {fileID: 500631745}
   - component: {fileID: 500631744}
+  - component: {fileID: 500631746}
+  - component: {fileID: 500631748}
+  - component: {fileID: 500631747}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -1291,6 +1388,7 @@ MonoBehaviour:
   - {fileID: 942978091}
   - {fileID: 581116052}
   - {fileID: 1116413903}
+  startingMoney: 10
 --- !u!4 &500631745
 Transform:
   m_ObjectHideFlags: 0
@@ -1306,6 +1404,48 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &500631746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 500631743}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a84e28d2ee89bcd4caddae8295e5fe25, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &500631747
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 500631743}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5fdd403e7be00c4db2dc81acd75abfd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  originPosition: {x: -9, y: -5, z: 0}
+  width: 18
+  height: 10
+  cellSize: 1
+--- !u!114 &500631748
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 500631743}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45367cd45ecbf73489888b44e0579c36, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  towerPrefab: {fileID: 8974914344815011484, guid: f3a91c6d2f2ee1e4c8bf7b6c2a101adc, type: 3}
+  towerGhost: {fileID: 547819837}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -1429,6 +1569,178 @@ Transform:
   m_Children: []
   m_Father: {fileID: 875236583}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &547819837
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 547819839}
+  - component: {fileID: 547819838}
+  - component: {fileID: 547819841}
+  - component: {fileID: 547819840}
+  - component: {fileID: 547819842}
+  m_Layer: 0
+  m_Name: TowerGhost
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &547819838
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 547819837}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 0, g: 1, b: 0, a: 0.19607843}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &547819839
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 547819837}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -9.5, y: 5.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &547819840
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 547819837}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!50 &547819841
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 547819837}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!114 &547819842
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 547819837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eebb89eac1e93d9419f8393429c25520, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &567851641
 GameObject:
   m_ObjectHideFlags: 0
@@ -2563,6 +2875,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1206358324}
   - component: {fileID: 1206358325}
+  - component: {fileID: 1206358326}
   m_Layer: 0
   m_Name: Square (3)
   m_TagString: Untagged
@@ -2579,7 +2892,7 @@ Transform:
   m_GameObject: {fileID: 1206358323}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: 0.99196565, w: 0.12650776}
-  m_LocalPosition: {x: 1.04, y: 1.05, z: -0.049875434}
+  m_LocalPosition: {x: 1.04, y: 1.05, z: 0}
   m_LocalScale: {x: 2.8154883, y: 0.875, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2637,6 +2950,52 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &1206358326
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1206358323}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &1209604750
 GameObject:
   m_ObjectHideFlags: 0
@@ -2833,6 +3192,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1337881132}
   - component: {fileID: 1337881133}
+  - component: {fileID: 1337881134}
   m_Layer: 0
   m_Name: Square
   m_TagString: Untagged
@@ -2849,7 +3209,7 @@ Transform:
   m_GameObject: {fileID: 1337881131}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -6.89, y: 0, z: -0.049875434}
+  m_LocalPosition: {x: -6.89, y: 0, z: 0}
   m_LocalScale: {x: 3.8875, y: 0.875, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2907,6 +3267,52 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &1337881134
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1337881131}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &1354739557
 GameObject:
   m_ObjectHideFlags: 0
@@ -3227,6 +3633,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1663570564}
   - component: {fileID: 1663570565}
+  - component: {fileID: 1663570566}
   m_Layer: 0
   m_Name: Square (7)
   m_TagString: Untagged
@@ -3243,7 +3650,7 @@ Transform:
   m_GameObject: {fileID: 1663570563}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7.1, y: -0.97, z: -0.049875434}
+  m_LocalPosition: {x: 7.1, y: -0.97, z: 0}
   m_LocalScale: {x: 3.4302187, y: 0.875, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3301,6 +3708,52 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &1663570566
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1663570563}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &1693985573
 GameObject:
   m_ObjectHideFlags: 0
@@ -3311,6 +3764,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1693985574}
   - component: {fileID: 1693985575}
+  - component: {fileID: 1693985576}
   m_Layer: 0
   m_Name: Square (4)
   m_TagString: Untagged
@@ -3327,7 +3781,7 @@ Transform:
   m_GameObject: {fileID: 1693985573}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: 0.3158803, w: 0.94879913}
-  m_LocalPosition: {x: 0.53, y: 2.13, z: -0.049875434}
+  m_LocalPosition: {x: 0.53, y: 2.13, z: 0}
   m_LocalScale: {x: 2.8154883, y: 0.875, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3385,6 +3839,52 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &1693985576
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1693985573}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &1709936717
 GameObject:
   m_ObjectHideFlags: 0
@@ -3643,6 +4143,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1790631259}
   - component: {fileID: 1790631260}
+  - component: {fileID: 1790631261}
   m_Layer: 0
   m_Name: Square (1)
   m_TagString: Untagged
@@ -3659,7 +4160,7 @@ Transform:
   m_GameObject: {fileID: 1790631258}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0.3158862, w: 0.9487971}
-  m_LocalPosition: {x: -3.16, y: -1.48, z: -0.049875434}
+  m_LocalPosition: {x: -3.16, y: -1.48, z: 0}
   m_LocalScale: {x: 5.2543454, y: 0.875, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3717,6 +4218,52 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &1790631261
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1790631258}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &1792090366
 GameObject:
   m_ObjectHideFlags: 0
@@ -3789,6 +4336,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1825946907}
   - component: {fileID: 1825946908}
+  - component: {fileID: 1825946909}
   m_Layer: 0
   m_Name: Square (6)
   m_TagString: Untagged
@@ -3805,7 +4353,7 @@ Transform:
   m_GameObject: {fileID: 1825946906}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0.8654373, w: 0.50101715}
-  m_LocalPosition: {x: 6.56, y: 0.5, z: -0.049875434}
+  m_LocalPosition: {x: 6.56, y: 0.5, z: 0}
   m_LocalScale: {x: 3.4302187, y: 0.875, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -3863,6 +4411,52 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &1825946909
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1825946906}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &1838067872
 GameObject:
   m_ObjectHideFlags: 0
@@ -3987,13 +4581,13 @@ Transform:
   m_Children:
   - {fileID: 1337881132}
   - {fileID: 1790631259}
-  - {fileID: 295984896}
   - {fileID: 102488505}
   - {fileID: 1206358324}
   - {fileID: 1693985574}
   - {fileID: 2021820905}
   - {fileID: 1825946907}
   - {fileID: 1663570564}
+  - {fileID: 295984896}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1894291184
@@ -4161,6 +4755,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2021820905}
   - component: {fileID: 2021820906}
+  - component: {fileID: 2021820907}
   m_Layer: 0
   m_Name: Square (5)
   m_TagString: Untagged
@@ -4177,7 +4772,7 @@ Transform:
   m_GameObject: {fileID: 2021820904}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0.100367166, w: 0.99495053}
-  m_LocalPosition: {x: 4.15, y: 2.31, z: -0.049875434}
+  m_LocalPosition: {x: 4.15, y: 2.31, z: 0}
   m_LocalScale: {x: 5.9969907, y: 0.875, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -4235,6 +4830,52 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &2021820907
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2021820904}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &2025386802
 GameObject:
   m_ObjectHideFlags: 0
@@ -4625,3 +5266,4 @@ SceneRoots:
   - {fileID: 8176057446884330653}
   - {fileID: 500631745}
   - {fileID: 607781301}
+  - {fileID: 547819839}

--- a/Defend The Divine/Assets/Scripts/GameManager.cs
+++ b/Defend The Divine/Assets/Scripts/GameManager.cs
@@ -8,6 +8,9 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager Instance;
 
+    public InputManager InputManager { get; private set; }
+    public Grid Grid { get; private set; }
+
     [HideInInspector] 
     public List<Enemy> enemies;
 
@@ -30,6 +33,9 @@ public class GameManager : MonoBehaviour
             Instance = this;
         }
         money = startingMoney;
+
+        InputManager = GetComponent<InputManager>();
+        Grid = GetComponent<Grid>();
     }
 
     public Transform[] GetRandomPath() {

--- a/Defend The Divine/Assets/Scripts/Grid.cs
+++ b/Defend The Divine/Assets/Scripts/Grid.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Experimental.AI;
+
+public class Grid : MonoBehaviour
+{
+    [SerializeField]
+    private Vector3 originPosition;
+    [SerializeField]
+    public int width;
+    [SerializeField]
+    public int height;
+    [SerializeField]
+    public float cellSize;
+
+    private int[,] gridArray;
+
+    private void Start()
+    {
+        gridArray = new int[width, height];
+    }
+
+    private void Update()
+    {
+        updateDebug();
+    }
+
+    /// <summary>
+    /// Returns a the lower left corner of a tile based on world position
+    /// </summary>
+    /// <param name="x"></param>
+    /// <param name="y"></param>
+    /// <returns></returns>
+    public Vector3 GetWorldPosition(int x, int y)
+    {
+        return new Vector3(x, y, 0) * cellSize + originPosition;
+    }
+
+    /// <summary>
+    /// Returns the center of a tile based on coordinates
+    /// </summary>
+    /// <param name="x"></param>
+    /// <param name="y"></param>
+    /// <returns></returns>
+    public Vector3 GetTileCenter(int x, int y)
+    {
+        return GetWorldPosition(x, y) + new Vector3(cellSize / 2f, cellSize / 2f, 0);
+    }
+
+    /// <summary>
+    /// Returns the indecies of the tile containing 'worldPosition'
+    /// </summary>
+    /// <param name="worldPosition"></param>
+    /// <param name="x"></param>
+    /// <param name="y"></param>
+    public void GetXY(Vector3 worldPosition, out int x, out int y)
+    {
+        x = Mathf.FloorToInt((worldPosition - originPosition).x / cellSize);
+        y = Mathf.FloorToInt((worldPosition - originPosition).y / cellSize);
+    }
+
+    /// <summary>
+    /// Sets the value of the grid's 'gridArray' at [x, y]
+    /// </summary>
+    /// <param name="x"></param>
+    /// <param name="y"></param>
+    /// <param name="value"></param>
+    public void SetValue(int x, int y, int value)
+    {
+        if (x >= 0 && y >= 0 && x < width && y < height)
+        {
+            gridArray[x, y] = value;
+        }
+    }
+
+    /// <summary>
+    /// Sets the value of the grid's 'gridArray' at the [x, y] tile containing
+    /// 'worldPosition'
+    /// </summary>
+    /// <param name="worldPosition"></param>
+    /// <param name="value"></param>
+    public void SetValue(Vector3 worldPosition, int value)
+    {
+        int x, y;
+        GetXY(worldPosition, out x, out y);
+        SetValue(x, y, value);
+    }
+
+    public int GetValue(int x, int y)
+    {
+        return gridArray[x, y];
+    }
+
+    public int GetValue(Vector3 worldPosition)
+    {
+        int x, y;
+        GetXY(worldPosition, out x, out y);
+        return GetValue(x, y);
+    }
+
+    private Color cellColor = Color.red;
+    /// <summary>
+    /// Redraws the debug grid lines
+    /// </summary>
+    public void updateDebug()
+    {
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                if (gridArray[x, y] == 1)
+                {
+                    cellColor = Color.green;
+                }
+                else
+                {
+                    cellColor = Color.red;
+                }
+                Debug.DrawLine(GetWorldPosition(x, y), GetWorldPosition(x, y + 1), cellColor, 2f, false);
+                Debug.DrawLine(GetWorldPosition(x, y), GetWorldPosition(x + 1, y), cellColor, 2f, false);
+            }
+        }
+
+        Debug.DrawLine(GetWorldPosition(width, 0), GetWorldPosition(width, height), cellColor, 2f, false);
+        Debug.DrawLine(GetWorldPosition(0, height), GetWorldPosition(width, height), cellColor, 2f, false);
+    }
+}

--- a/Defend The Divine/Assets/Scripts/Grid.cs.meta
+++ b/Defend The Divine/Assets/Scripts/Grid.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5fdd403e7be00c4db2dc81acd75abfd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Defend The Divine/Assets/Scripts/InputManager.cs
+++ b/Defend The Divine/Assets/Scripts/InputManager.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class InputManager : MonoBehaviour
+{
+    // Public properties
+    public bool MouseLeftDown
+    {
+        get;
+        private set;
+    }
+
+    public bool MouseLeftDownThisFrame
+    {
+        get;
+        private set;
+    }
+
+    public Vector3 MouseWorldPosition
+    {
+        get;
+        private set;
+    }
+
+    // Update is called once per frame
+    public void Update()
+    {
+        // The "new" Unity Input System's mouse state getter
+        Mouse mouse = Mouse.current;
+
+        MouseLeftDown = mouse.leftButton.isPressed;
+        MouseLeftDownThisFrame = mouse.leftButton.wasPressedThisFrame;
+
+        // Mouse.position is an object, needs ReadValue() call to get value
+        Vector3 screenSpaceLocation = mouse.position.ReadValue();
+        // Convert the mouse's screen position to its equivalent position in the scene
+        MouseWorldPosition = Camera.main.ScreenToWorldPoint(screenSpaceLocation);
+    }
+}

--- a/Defend The Divine/Assets/Scripts/InputManager.cs.meta
+++ b/Defend The Divine/Assets/Scripts/InputManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a84e28d2ee89bcd4caddae8295e5fe25
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Defend The Divine/Assets/Scripts/TowerGhost.cs
+++ b/Defend The Divine/Assets/Scripts/TowerGhost.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class TowerGhost : MonoBehaviour
+{
+    public bool CollidingWithPath {  get; private set; }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        CollidingWithPath = false;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    private void OnTriggerEnter2D(Collider2D collider)
+    {
+        CollidingWithPath = true;
+    }
+
+    // Needed to fix a bug where the tower ghost wouldn't count as "entering"
+    // a trigger when already in a box, allowing tower placement in the path.
+    private void OnTriggerStay2D(Collider2D collision)
+    {
+        CollidingWithPath = true;
+    }
+
+    private void OnTriggerExit2D(Collider2D other)
+    {
+        CollidingWithPath = false;
+    }
+}

--- a/Defend The Divine/Assets/Scripts/TowerGhost.cs.meta
+++ b/Defend The Divine/Assets/Scripts/TowerGhost.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eebb89eac1e93d9419f8393429c25520
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Defend The Divine/Assets/Scripts/TowerPlacement.cs
+++ b/Defend The Divine/Assets/Scripts/TowerPlacement.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Data.Common;
+using UnityEditor;
+using UnityEngine;
+
+public class TowerPlacement : MonoBehaviour
+{
+    [SerializeField]
+    private GameObject towerPrefab;
+    [SerializeField]
+    private GameObject towerGhost;
+
+    private bool canPlaceTower = true;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        GameManager manager = GameManager.Instance;
+        int gridX, gridY;
+        manager.Grid.GetXY(manager.InputManager.MouseWorldPosition, out gridX, out gridY);
+
+        // A tower may be placed when:
+        //  * the ghost isn't colliding with a path
+        //  * there isn't already a tower in the current spot
+        canPlaceTower = 
+            !towerGhost.GetComponent<TowerGhost>().CollidingWithPath
+            && manager.Grid.GetValue(gridX, gridY) != 1;
+
+        towerGhost.transform.position = manager.Grid.GetTileCenter(gridX, gridY);
+
+        // Show when a tower can be placed
+        SpriteRenderer towerGhostSR = towerGhost.GetComponent<SpriteRenderer>();
+        if (canPlaceTower)
+        {
+            towerGhostSR.enabled = true;
+        }
+        else
+        {
+            towerGhostSR.enabled = false;
+        }
+
+        if (manager.InputManager.MouseLeftDownThisFrame && canPlaceTower)
+        {
+            GameObject.Instantiate(towerPrefab, manager.Grid.GetTileCenter(gridX, gridY), Quaternion.identity);
+            manager.Grid.SetValue(gridX, gridY, 1);
+        }
+    }
+}

--- a/Defend The Divine/Assets/Scripts/TowerPlacement.cs.meta
+++ b/Defend The Divine/Assets/Scripts/TowerPlacement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45367cd45ecbf73489888b44e0579c36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Defend The Divine/Packages/manifest.json
+++ b/Defend The Divine/Packages/manifest.json
@@ -4,6 +4,7 @@
     "com.unity.feature.2d": "2.0.0",
     "com.unity.ide.rider": "3.0.24",
     "com.unity.ide.visualstudio": "2.0.18",
+    "com.unity.inputsystem": "1.7.0",
     "com.unity.test-framework": "1.3.9",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.8.2",

--- a/Defend The Divine/Packages/packages-lock.json
+++ b/Defend The Divine/Packages/packages-lock.json
@@ -159,6 +159,15 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.inputsystem": {
+      "version": "1.7.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.mathematics": {
       "version": "1.2.6",
       "depth": 2,

--- a/Defend The Divine/ProjectSettings/ProjectSettings.asset
+++ b/Defend The Divine/ProjectSettings/ProjectSettings.asset
@@ -698,7 +698,7 @@ PlayerSettings:
   hmiLogStartupTiming: 0
   hmiCpuConfiguration: 
   apiCompatibilityLevel: 6
-  activeInputHandler: 0
+  activeInputHandler: 2
   windowsGamepadBackendHint: 0
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0


### PR DESCRIPTION
There is now a world grid (accessible via GameManager instance), the camera has been set to 16:9, towers can be placed on the grid, and the game visually shows you when you can place a tower.

I also added the "new" Unity Input System package and set up an Input Manager class that is accessible via the GameManager instance.