### PR TITLE
Upgradeable Tower Code & Negative Money Fix

### DIFF
--- a/Defend The Divine/Assets/Prefabs/Towers/CannonTower.prefab
+++ b/Defend The Divine/Assets/Prefabs/Towers/CannonTower.prefab
@@ -101,10 +101,19 @@ MonoBehaviour:
   damage: 7
   projectileSpeed: 20
   range: 5
-  SHOOT_DELAY: 1.2
+  ATTACK_DELAY: 0.5
   cost: 5
   damagingPrefab: {fileID: 474679912698572556, guid: d760f47b006601e43a3027800f6f82b2, type: 3}
   uiPopupPrefab: {fileID: 5480922836673919474, guid: c64acfdfba45b3244a6a8d3fd3ee2e76, type: 3}
+  damageUpgradeAmount: 0.5
+  damageUpgradeCost: 3
+  maxDamageUpgradeLevel: 8
+  rangeUpgradeAmount: 0.5
+  rangeUpgradeCost: 3
+  maxRangeUpgradeLevel: 8
+  attackSpeedUpgradeAmount: 0.05
+  attackSpeedUpgradeCost: 3
+  maxAttackSpeedUpgradeLevel: 8
 --- !u!58 &557187313376879698
 CircleCollider2D:
   m_ObjectHideFlags: 0

--- a/Defend The Divine/Assets/Prefabs/Towers/SwordTower.prefab
+++ b/Defend The Divine/Assets/Prefabs/Towers/SwordTower.prefab
@@ -186,10 +186,19 @@ MonoBehaviour:
   damage: 10
   projectileSpeed: 15
   range: 2.1
-  SHOOT_DELAY: 2.5
+  ATTACK_DELAY: 0.5
   cost: 10
   damagingPrefab: {fileID: 6194810038108574417}
   uiPopupPrefab: {fileID: 0}
+  damageUpgradeAmount: 0.5
+  damageUpgradeCost: 3
+  maxDamageUpgradeLevel: 8
+  rangeUpgradeAmount: 0.1
+  rangeUpgradeCost: 3
+  maxRangeUpgradeLevel: 8
+  attackSpeedUpgradeAmount: 0.05
+  attackSpeedUpgradeCost: 3
+  maxAttackSpeedUpgradeLevel: 8
   rotationSpeed: 2500
   swordSpriteRenderer: {fileID: 1443375537974400236}
 --- !u!58 &6161489313166050419

--- a/Defend The Divine/Assets/Scenes/Main Level.unity
+++ b/Defend The Divine/Assets/Scenes/Main Level.unity
@@ -1777,9 +1777,10 @@ MonoBehaviour:
   - {fileID: 942978091}
   - {fileID: 581116052}
   - {fileID: 1116413903}
-  startingMoney: 15
+  startingMoney: 35
   towerUiCanvas: {fileID: 0}
   moneyText: {fileID: 1411268898}
+  towerPlacement: {fileID: 500631748}
 --- !u!4 &500631745
 Transform:
   m_ObjectHideFlags: 0
@@ -1821,7 +1822,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   towerPrefab: {fileID: -7116430699302381254, guid: f3a91c6d2f2ee1e4c8bf7b6c2a101adc, type: 3}
   towerGhost: {fileID: 547819842}
-  currentTowerType: 1
+  currentTowerType: 0
   towerType1Prefab: {fileID: -7116430699302381254, guid: f3a91c6d2f2ee1e4c8bf7b6c2a101adc, type: 3}
   towerType2Prefab: {fileID: 1862400210719592098, guid: dd35b88adc3577d4294cd37d1576807c, type: 3}
 --- !u!114 &500631749
@@ -1855,6 +1856,7 @@ MonoBehaviour:
   enemySpawnPositions:
   - {fileID: 1473024243}
   - {fileID: 940715083}
+  currentWave: 0
 --- !u!114 &500631751
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1872,7 +1874,7 @@ MonoBehaviour:
   spell2Button: {fileID: 951848392}
   spell3Button: {fileID: 2078158192}
   FreezeSpellPrefab: {fileID: 8205279509571411624, guid: f71e8f72f4f9b7d40b58e416910a2c76, type: 3}
-  freezeSpellCooldown: 1
+  freezeSpellCooldown: 5
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0

--- a/Defend The Divine/Assets/Scripts/Enemies/Enemy.cs
+++ b/Defend The Divine/Assets/Scripts/Enemies/Enemy.cs
@@ -59,7 +59,7 @@ public class Enemy : Entity {
     protected void OnTriggerEnter2D(Collider2D collision) {
         if (collision.gameObject.CompareTag("DivinePillar")) {
             collision.gameObject.GetComponent<DivinePillar>().TakeDamage(damage);
-            GameManager.Instance.RemoveEnemy(enemyComponent);
+            GameManager.Instance.RemoveEnemy(this);
             Destroy(gameObject);
         }
     }

--- a/Defend The Divine/Assets/Scripts/GameManager.cs
+++ b/Defend The Divine/Assets/Scripts/GameManager.cs
@@ -37,11 +37,16 @@ public class GameManager : MonoBehaviour
     private WaveManager waveManager;
     public WaveManager WaveManager { get { return waveManager; } }
 
+    public TowerPlacement towerPlacement;
+
     public int Money { get { return money; } }
 
     private void Awake() {
         if (Instance == null) {
             Instance = this;
+        }
+        if (towerPlacement == null) {
+            towerPlacement = GetComponent<TowerPlacement>();
         }
         money = startingMoney;
         waveManager = GetComponent<WaveManager>();

--- a/Defend The Divine/Assets/Scripts/Towers/SwordTower.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/SwordTower.cs
@@ -40,7 +40,7 @@ public class SwordTower : Tower
     }
 
     protected override void Attack(Enemy target) {
-        shootTimer = SHOOT_DELAY;
+        shootTimer = ATTACK_DELAY;
         ContinueSwing();
         isSwinging = true;
         swordSpriteRenderer.enabled = true;

--- a/Defend The Divine/Assets/Scripts/Towers/Tower.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/Tower.cs
@@ -15,9 +15,9 @@ public class Tower : MonoBehaviour, IPointerClickHandler
     [SerializeField]
     protected float range = 5f;
 
-    /* Use as a const */
+    /* Use as a const, only to be changed in UpgradeAttackSpeed */
     [SerializeField]
-    protected float SHOOT_DELAY = 0.5f;
+    protected float ATTACK_DELAY = 0.5f;
 
     protected float shootTimer = 0.05f;
 
@@ -33,6 +33,22 @@ public class Tower : MonoBehaviour, IPointerClickHandler
     [SerializeField]
     protected GameObject uiPopupPrefab;
 
+    [Header("Upgrade Amounts")]
+    [SerializeField] protected float damageUpgradeAmount = 0.5f;
+    [SerializeField] protected int damageUpgradeCost = 3;
+    [SerializeField] protected int maxDamageUpgradeLevel = 8;
+    [SerializeField] protected float rangeUpgradeAmount = 0.5f;
+    [SerializeField] protected int rangeUpgradeCost = 3;
+    [SerializeField] protected int maxRangeUpgradeLevel = 8;
+    [SerializeField] protected float attackSpeedUpgradeAmount = 0.05f;
+    [SerializeField] protected int attackSpeedUpgradeCost = 3;
+    [SerializeField] protected int maxAttackSpeedUpgradeLevel = 8;
+
+    /* Current Upgrade Level*/
+    protected int damageLevel = 1;
+    protected int rangeLevel = 1;
+    protected int attackSpeedLevel = 1;
+
     public int Cost { get { return cost; } }
 
     protected virtual void Update() {
@@ -46,7 +62,7 @@ public class Tower : MonoBehaviour, IPointerClickHandler
     }
 
     protected virtual void Attack(Enemy target) {
-        shootTimer = SHOOT_DELAY;
+        shootTimer = ATTACK_DELAY;
         GameObject proj = Instantiate(damagingPrefab, transform.position, Quaternion.identity);
         Projectile projectile = proj.GetComponent<Projectile>();
         projectile.SetTarget(target.transform.position);
@@ -122,6 +138,27 @@ public class Tower : MonoBehaviour, IPointerClickHandler
             hasCreatedUI = true;
         }
         createdUi.SetActive(true);
+    }
+
+    protected void UpgradeDamage() {
+        if (damageLevel < maxDamageUpgradeLevel && GameManager.Instance.Money >= damageUpgradeCost) {
+            damage += damageUpgradeAmount;
+            GameManager.Instance.AddMoney(-damageUpgradeCost);
+        }
+    }
+
+    protected void UpgradeRange() {
+        if (rangeLevel < maxRangeUpgradeLevel && GameManager.Instance.Money >= rangeUpgradeCost) {
+            range += rangeUpgradeAmount;
+            GameManager.Instance.AddMoney(-rangeUpgradeCost);
+        }
+    }
+
+    protected void UpgradeAttackSpeed() {
+        if (attackSpeedLevel < maxAttackSpeedUpgradeLevel && GameManager.Instance.Money >= attackSpeedUpgradeCost) {
+            ATTACK_DELAY -= attackSpeedUpgradeAmount;
+            GameManager.Instance.AddMoney(-attackSpeedUpgradeCost);
+        }
     }
 
 }

--- a/Defend The Divine/Assets/Scripts/Towers/TowerPlacement.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/TowerPlacement.cs
@@ -47,20 +47,22 @@ public class TowerPlacement : MonoBehaviour
 
         if (GameManager.Instance.inputManager.MouseLeftDownThisFrame && canPlaceTower)
         {
-            switch (currentTowerType)
-            {
-                case TowerType.tower1:
-                    towerPrefab = towerType1Prefab;
-                    break;
-                case TowerType.tower2:
-                    towerPrefab = towerType2Prefab;
-                    break;
-                default:
-                    break;
-            }
-
+            
             GameObject.Instantiate(towerPrefab, towerGhost.transform.position, Quaternion.identity);
             GameManager.Instance.AddMoney(-towerPrefab.Cost);
+        }
+    }
+
+    public void SetCurrentTowerType(TowerType towerType) {
+        switch (towerType) {
+            case TowerType.tower1:
+                towerPrefab = towerType1Prefab;
+                break;
+            case TowerType.tower2:
+                towerPrefab = towerType2Prefab;
+                break;
+            default:
+                break;
         }
     }
 }

--- a/Defend The Divine/Assets/Scripts/UI-UX/TowerSelect.cs
+++ b/Defend The Divine/Assets/Scripts/UI-UX/TowerSelect.cs
@@ -1,34 +1,18 @@
-using System.Collections;
-using System.Collections.Generic;
-using TMPro;
 using UnityEngine;
 
 public class TowerSelect : MonoBehaviour
 {
-
     [SerializeField] private TowerPlacement.TowerType towerType = TowerPlacement.TowerType.tower1;
-
-    // Start is called before the first frame update
-    void Start()
-    {
-
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-
-    }
 
     public void OnClick()
     {
         switch (towerType)
         {
             case TowerPlacement.TowerType.tower1:
-                GameManager.Instance.GetComponent<TowerPlacement>().currentTowerType = TowerPlacement.TowerType.tower1;
+                GameManager.Instance.towerPlacement.SetCurrentTowerType(TowerPlacement.TowerType.tower1);
                 break;
             case TowerPlacement.TowerType.tower2:
-                GameManager.Instance.GetComponent<TowerPlacement>().currentTowerType = TowerPlacement.TowerType.tower2;
+                GameManager.Instance.towerPlacement.SetCurrentTowerType(TowerPlacement.TowerType.tower2);
                 break;
             default:
                 break;


### PR DESCRIPTION
Logic to handle tower upgrading, needs hooking up to buttons

Negative money fixed: Tower selection now updates tower to place immediately resulting in player not able to go into negative money from placing a tower