### PR TITLE
Playtest Improvements

### DIFF
--- a/Defend The Divine/Assets/Prefabs/DivinePillar.prefab
+++ b/Defend The Divine/Assets/Prefabs/DivinePillar.prefab
@@ -145,7 +145,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d08ec9f8553e35d488831c6995f8ebc6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 500
+  maxHealth: 100
+  healthText: {fileID: 0}
 --- !u!50 &9168538538306819079
 Rigidbody2D:
   serializedVersion: 4

--- a/Defend The Divine/Assets/Prefabs/Enemies/BasicEnemy.prefab
+++ b/Defend The Divine/Assets/Prefabs/Enemies/BasicEnemy.prefab
@@ -277,7 +277,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxHealth: 50
   healthBar: {fileID: 4050941158215385982}
-  damage: 10
+  damage: 5
   moveSpeed: 1.2
   moneyValue: 1
   bloodSplatter: {fileID: 8344524889168070583, guid: 6a2ea6338722cdb47a9a805b804848c6, type: 3}

--- a/Defend The Divine/Assets/Prefabs/Enemies/FastEnemy.prefab
+++ b/Defend The Divine/Assets/Prefabs/Enemies/FastEnemy.prefab
@@ -169,7 +169,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   maxHealth: 25
   healthBar: {fileID: 4050941158215385982}
-  damage: 10
+  damage: 5
   moveSpeed: 2.4
   moneyValue: 1
   bloodSplatter: {fileID: 8344524889168070583, guid: 6a2ea6338722cdb47a9a805b804848c6, type: 3}

--- a/Defend The Divine/Assets/Prefabs/Enemies/TankyEnemy.prefab
+++ b/Defend The Divine/Assets/Prefabs/Enemies/TankyEnemy.prefab
@@ -171,9 +171,9 @@ MonoBehaviour:
   healthBar: {fileID: 4050941158215385982}
   damage: 10
   moveSpeed: 1
+  moneyValue: 4
   bloodSplatter: {fileID: 8344524889168070583, guid: 6a2ea6338722cdb47a9a805b804848c6, type: 3}
   damageFlash: {r: 1, g: 0, b: 0, a: 1}
-  moneyValue: 4
 --- !u!1001 &4761788284441576474
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Defend The Divine/Assets/Prefabs/Towers/CannonTower.prefab
+++ b/Defend The Divine/Assets/Prefabs/Towers/CannonTower.prefab
@@ -101,7 +101,7 @@ MonoBehaviour:
   damage: 4
   range: 3.75
   ATTACK_DELAY: 0.2
-  cost: 15
+  cost: 30
   damagingPrefab: {fileID: 474679912698572556, guid: d760f47b006601e43a3027800f6f82b2, type: 3}
   uiPopupPrefab: {fileID: 5480922836673919474, guid: c64acfdfba45b3244a6a8d3fd3ee2e76, type: 3}
   rangePrefab: {fileID: 5404175338507898556, guid: 55cd93df1269c08478f7016ced343dd9, type: 3}

--- a/Defend The Divine/Assets/Prefabs/Towers/PiercingTower.prefab
+++ b/Defend The Divine/Assets/Prefabs/Towers/PiercingTower.prefab
@@ -137,7 +137,7 @@ MonoBehaviour:
   damage: 7
   range: 4
   ATTACK_DELAY: 0.5
-  cost: 25
+  cost: 50
   damagingPrefab: {fileID: 474679912698572556, guid: fd7fc8191959b504b8c58dac7eef2f45, type: 3}
   uiPopupPrefab: {fileID: 5480922836673919474, guid: c64acfdfba45b3244a6a8d3fd3ee2e76, type: 3}
   rangePrefab: {fileID: 5404175338507898556, guid: 55cd93df1269c08478f7016ced343dd9, type: 3}

--- a/Defend The Divine/Assets/Prefabs/Towers/SwordTower.prefab
+++ b/Defend The Divine/Assets/Prefabs/Towers/SwordTower.prefab
@@ -186,7 +186,7 @@ MonoBehaviour:
   damage: 10
   range: 2.1
   ATTACK_DELAY: 0.75
-  cost: 20
+  cost: 40
   damagingPrefab: {fileID: 6194810038108574417}
   uiPopupPrefab: {fileID: 5480922836673919474, guid: c64acfdfba45b3244a6a8d3fd3ee2e76, type: 3}
   rangePrefab: {fileID: 5404175338507898556, guid: 55cd93df1269c08478f7016ced343dd9, type: 3}

--- a/Defend The Divine/Assets/Scenes/Main Level.unity
+++ b/Defend The Divine/Assets/Scenes/Main Level.unity
@@ -746,7 +746,7 @@ GameObject:
   - component: {fileID: 152013812}
   - component: {fileID: 152013811}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: SwordTowerPrice
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -768,7 +768,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -20.5}
+  m_AnchoredPosition: {x: 0, y: -21.400005}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &152013811
@@ -880,7 +880,7 @@ GameObject:
   - component: {fileID: 155105859}
   - component: {fileID: 155105858}
   m_Layer: 5
-  m_Name: 'COST: $30'
+  m_Name: FreezeSpellPrice
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -902,7 +902,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 11.636, y: -23.8}
+  m_AnchoredPosition: {x: 25.2, y: -24.700005}
   m_SizeDelta: {x: 63.2721, y: 12.2909}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &155105858
@@ -925,7 +925,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'COST: $30'
+  m_text: $30
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -1384,7 +1384,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 60.5, y: 0}
+  m_AnchoredPosition: {x: 66.200005, y: 0}
   m_SizeDelta: {x: 6.3659, y: 48.6571}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &303784074
@@ -1614,7 +1614,7 @@ GameObject:
   - component: {fileID: 327545528}
   - component: {fileID: 327545527}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: PiercingTowerPrice
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1636,7 +1636,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -20.5}
+  m_AnchoredPosition: {x: 0, y: -21.4}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &327545527
@@ -2220,8 +2220,12 @@ MonoBehaviour:
   startingMoney: 60
   towerUiCanvas: {fileID: 50174059}
   spellActivate: {fileID: 500631751}
-  moneyText: {fileID: 1411268898}
   towerPlacement: {fileID: 500631748}
+  moneyText: {fileID: 1411268898}
+  cannonTowerCost: {fileID: 847215456}
+  swordTowerCost: {fileID: 152013811}
+  piercingTowerCost: {fileID: 327545527}
+  freezeSpellCost: {fileID: 155105858}
 --- !u!4 &500631745
 Transform:
   m_ObjectHideFlags: 0
@@ -3120,8 +3124,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: The Piercing Tower is an improved Cannon Tower that damages multiple enemies
-    in a row.
+  m_text: The Piercing Tower is an improved Cannon Tower that damages 4 enemies in
+    a row.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3441,7 +3445,7 @@ GameObject:
   - component: {fileID: 847215457}
   - component: {fileID: 847215456}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: CannonTowerPrice
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3463,7 +3467,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -20.5}
+  m_AnchoredPosition: {x: 0, y: -21.400005}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &847215456
@@ -4059,7 +4063,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.74750006, y: 0}
   m_AnchorMax: {x: 0.74750006, y: 0}
-  m_AnchoredPosition: {x: 60.30002, y: 25}
+  m_AnchoredPosition: {x: 66.000015, y: 25}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &951848392
@@ -4411,7 +4415,8 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: The Freeze Spell is a slow moving wave which freezes eneimes in place.
+  m_text: The Freeze Spell is a slow moving wave which freezes enemies in place for
+    5 seconds. Has a 15 second cooldown.
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -5118,7 +5123,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.4, y: 0}
   m_AnchorMax: {x: 0.4, y: 0}
-  m_AnchoredPosition: {x: 60, y: 26.677}
+  m_AnchoredPosition: {x: 65.700005, y: 28.20001}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1199311836
@@ -5215,14 +5220,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.0627451, g: 0.99215686, b: 1, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: e859f89337895da49affd3a6c9764042, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 0c34d1a8681d1b847a07770745889abb, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -5472,7 +5477,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5975, y: 0}
   m_AnchorMax: {x: 0.5975, y: 0}
-  m_AnchoredPosition: {x: 60.5, y: 26.677}
+  m_AnchoredPosition: {x: 66.200005, y: 28.20001}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1223278616
@@ -5609,7 +5614,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.25, y: 0}
   m_AnchorMax: {x: 0.25, y: 0}
-  m_AnchoredPosition: {x: 0, y: 26.677}
+  m_AnchoredPosition: {x: 5.700012, y: 28.2}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1237214712
@@ -6329,7 +6334,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.1, y: 0}
   m_AnchorMax: {x: 0.1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 25}
+  m_AnchoredPosition: {x: 17.7, y: 34.7}
   m_SizeDelta: {x: 45.8656, y: 36.646}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1411268898
@@ -6352,7 +6357,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Money: '
+  m_text: $250
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -7204,6 +7209,140 @@ Transform:
   m_Children: []
   m_Father: {fileID: 875236583}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1712570884
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1712570887}
+  - component: {fileID: 1712570886}
+  - component: {fileID: 1712570885}
+  m_Layer: 5
+  m_Name: Health
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1712570885
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1712570884}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'HP: 100/100'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 12.2
+  m_fontSizeBase: 12.2
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -6.1925697, y: 0, z: -10.696295, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1712570886
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1712570884}
+  m_CullTransparentMesh: 1
+--- !u!224 &1712570887
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1712570884}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1833023094}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.1, y: 0}
+  m_AnchorMax: {x: 0.1, y: 0}
+  m_AnchoredPosition: {x: 3.800003, y: 15.100005}
+  m_SizeDelta: {x: 60, y: 36.646}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1730302982
 GameObject:
   m_ObjectHideFlags: 0
@@ -7398,7 +7537,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.4, y: 0}
   m_AnchorMax: {x: 0.4, y: 0}
-  m_AnchoredPosition: {x: 0, y: 26.677}
+  m_AnchoredPosition: {x: 5.700001, y: 28.20001}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1782768729
@@ -7470,14 +7609,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.02745098, g: 1, b: 0.003921569, a: 1}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: e859f89337895da49affd3a6c9764042, type: 3}
+  m_Sprite: {fileID: 21300000, guid: 325e7d1fce0f46340a11da828086bce0, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -7911,6 +8050,7 @@ RectTransform:
   - {fileID: 1223278615}
   - {fileID: 951848391}
   - {fileID: 1411268897}
+  - {fileID: 1712570887}
   - {fileID: 303784073}
   m_Father: {fileID: 50174063}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9387,6 +9527,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5698748551656801754, guid: 5c43ba7f4eedca045959c9c24fd56a4b, type: 3}
+      propertyPath: healthText
+      value: 
+      objectReference: {fileID: 1712570885}
     - target: {fileID: 5995002482926310397, guid: 5c43ba7f4eedca045959c9c24fd56a4b, type: 3}
       propertyPath: m_Name
       value: DivinePillar

--- a/Defend The Divine/Assets/Scripts/Enemies/Enemy.cs
+++ b/Defend The Divine/Assets/Scripts/Enemies/Enemy.cs
@@ -51,7 +51,6 @@ public class Enemy : Entity
     {
         base.Start();
         path = GameManager.Instance.GetRandomPath();
-        //transform.position = path[waypointIndex].transform.position;
     }
 
     private void Update()
@@ -142,10 +141,12 @@ public class Enemy : Entity
     IEnumerator FreezeCoroutine(float freezeDuration)
     {
         isFrozen = true;
+        animator.speed = 0;
 
         yield return new WaitForSeconds(freezeDuration);
 
         isFrozen = false;
+        animator.speed = 1;
     }
 
     IEnumerator DamageFlashCoroutine(float seconds = 0.1f)

--- a/Defend The Divine/Assets/Scripts/GameManager.cs
+++ b/Defend The Divine/Assets/Scripts/GameManager.cs
@@ -25,13 +25,17 @@ public class GameManager : MonoBehaviour
 
     [SerializeField] private SpellActivate spellActivate;
 
-    [SerializeField]
-    private TMP_Text moneyText;
-
     private WaveManager waveManager;
     public WaveManager WaveManager { get { return waveManager; } }
 
     public TowerPlacement towerPlacement;
+
+    [Header("UI Stuff")]
+    [SerializeField] private TMP_Text moneyText;
+    [SerializeField] private TMP_Text cannonTowerCost;
+    [SerializeField] private TMP_Text swordTowerCost;
+    [SerializeField] private TMP_Text piercingTowerCost;
+    [SerializeField] private TMP_Text freezeSpellCost;
 
     // Buttons
     private Button tower1Button;
@@ -83,6 +87,13 @@ public class GameManager : MonoBehaviour
         }
     }
 
+    private void Start() {
+        cannonTowerCost.text = $"${towerPlacement.towerType1Prefab.Cost}";
+        swordTowerCost.text = $"${towerPlacement.towerType2Prefab.Cost}";
+        piercingTowerCost.text = $"${towerPlacement.towerType3Prefab.Cost}";
+        freezeSpellCost.text = $"${spellActivate.FreezeSpellPrefab.Cost}";
+    }
+
     public Transform[] GetRandomPath() {
         int randomPath = Random.Range(0, 2);
         switch (randomPath) {
@@ -99,7 +110,7 @@ public class GameManager : MonoBehaviour
         UpdateButtonInteractability();
     }
 
-    private void UpdateButtonInteractability() {
+    public void UpdateButtonInteractability() {
         tower1Button.interactable = money < towerPlacement.towerType1Prefab.Cost ? false : true;
         tower2Button.interactable = money < towerPlacement.towerType2Prefab.Cost ? false : true;
         tower3Button.interactable = money < towerPlacement.towerType3Prefab.Cost ? false : true;

--- a/Defend The Divine/Assets/Scripts/Spells/SpellActivate.cs
+++ b/Defend The Divine/Assets/Scripts/Spells/SpellActivate.cs
@@ -32,6 +32,7 @@ public class SpellActivate : MonoBehaviour
                     StartCoroutine(FreezeSpellCoroutine());
                     Instantiate(FreezeSpellPrefab, divinePillar.transform.position, Quaternion.identity);
                     GameManager.Instance.AddMoney(-FreezeSpellPrefab.Cost);
+                    GameManager.Instance.towerPlacement.deselectTower();
                 }
                 break;
             case 1:
@@ -52,7 +53,7 @@ public class SpellActivate : MonoBehaviour
         yield return new WaitForSeconds(freezeSpellCooldown);
 
         isFreezeOnCooldown = false;
-        freezeSpellButton.interactable = true;
+        GameManager.Instance.UpdateButtonInteractability();
     }
 
 }

--- a/Defend The Divine/Assets/Scripts/Towers/DivinePillar.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/DivinePillar.cs
@@ -1,5 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -8,16 +7,21 @@ public class DivinePillar : MonoBehaviour
     [SerializeField]
     private int maxHealth = 100;
 
+    [SerializeField]
+    private TMP_Text healthText;
+
     private int health;
 
     public int Health { get { return health; } }
 
     private void Awake() {
         health = maxHealth;
+        TakeDamage(0);
     }
 
     public void TakeDamage(int damage) {
         health -= damage;
+        healthText.text = $"HP: {health}/{maxHealth}";
         if (health <= 0) {
             TowerDestroyed();
         }

--- a/Defend The Divine/Assets/Scripts/Towers/Tower.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/Tower.cs
@@ -3,35 +3,27 @@ using UnityEngine.EventSystems;
 
 public abstract class Tower : MonoBehaviour, IPointerClickHandler
 {
-    [SerializeField]
-    protected float damage = 5f;
-
-    [SerializeField]
-    protected float range = 5f;
+    [SerializeField] protected float damage = 5f;
+    [SerializeField] protected float range = 5f;
 
     /* Use as a const, only to be changed in UpgradeAttackSpeed */
-    [SerializeField]
-    protected float ATTACK_DELAY = 0.5f;
+    [SerializeField] protected float ATTACK_DELAY = 0.5f;
 
     protected float attackTimer = 0.05f;
 
-    [SerializeField]
-    protected int cost = 10;
+    [SerializeField] protected int cost = 10;
 
-    [SerializeField]
-    protected GameObject damagingPrefab;
+    [SerializeField] protected GameObject damagingPrefab;
 
     protected bool hasCreatedUI = false;
     protected bool mouseIsOver = false;
     protected GameObject createdUi;
     protected GameObject visibleRange;
 
-    [SerializeField]
-    protected GameObject uiPopupPrefab;
+    [Header("UI Stuff")]
+    [SerializeField] protected GameObject uiPopupPrefab;
+    [SerializeField] protected GameObject rangePrefab;
 
-    [SerializeField]
-    protected GameObject rangePrefab;
-    
     [Header("Upgrades")]
     [SerializeField] protected int upgradeCost = 3;
     [SerializeField] protected int maxUpgradeLevel = 4;

--- a/Defend The Divine/Assets/Scripts/Towers/TowerPlacement.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/TowerPlacement.cs
@@ -1,7 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using System.Data.Common;
-using UnityEditor;
 using UnityEngine;
 
 public class TowerPlacement : MonoBehaviour
@@ -59,27 +55,38 @@ public class TowerPlacement : MonoBehaviour
             Instantiate(currentTowerPrefab, currentGhostTower.transform.position, Quaternion.identity);
             GameManager.Instance.AddMoney(-currentTowerPrefab.Cost);
             currentTowerPrefab = null;
-            currentGhostTower.transform.position = new Vector2(0f, 255f);
-            currentGhostTower = null;
+            deselectTower();
+        }
+        else if (GameManager.Instance.inputManager.MouseRightDownThisFrame && currentGhostTower != null) {
+            deselectTower();
         }
     }
 
     public void SetCurrentTowerType(TowerType towerType) {
         switch (towerType) {
             case TowerType.tower1:
+                deselectTower();
                 currentTowerPrefab = towerType1Prefab;
                 currentGhostTower = tower1Ghost;
                 break;
             case TowerType.tower2:
+                deselectTower();
                 currentTowerPrefab = towerType2Prefab;
                 currentGhostTower = tower2Ghost;
                 break;
             case TowerType.tower3:
+                deselectTower();
                 currentTowerPrefab = towerType3Prefab;
                 currentGhostTower = tower3Ghost;
                 break;
             default:
                 break;
         }
+    }
+
+    public void deselectTower() {
+        if (currentGhostTower == null) return;
+        currentGhostTower.transform.position = new Vector2(0f, 255f);
+        currentGhostTower = null;
     }
 }

--- a/Defend The Divine/Assets/Scripts/UI-UX/ButtonInfoPopup.cs
+++ b/Defend The Divine/Assets/Scripts/UI-UX/ButtonInfoPopup.cs
@@ -6,7 +6,7 @@ using UnityEngine.EventSystems;
 
 public class ButtonInfoPopup : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
 {
-    private const float MAX_TIME = 2f;
+    private const float MAX_TIME = 0.25f;
     private float timer = MAX_TIME;
     bool isTimerTicking = false;
     


### PR DESCRIPTION
Added many of the improvements talked about during today's playtest:
- Fixed switching between ghost towers
- Fixed freeze spell interactable = true bug while on cooldown
- Ability to deselect ghost tower (right click)
- Freeze enemy animations when hit by freeze wave
- decrease tower info popup time to 0.25s
- Tower & spell cost values are set via code
- Decrease DivinePillar health