### PR TITLE
Added camera shake

### DIFF
--- a/Defend The Divine/Assets/Scenes/Main Level.unity
+++ b/Defend The Divine/Assets/Scenes/Main Level.unity
@@ -2330,6 +2330,7 @@ GameObject:
   - component: {fileID: 519420031}
   - component: {fileID: 519420029}
   - component: {fileID: 519420033}
+  - component: {fileID: 519420034}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -2427,6 +2428,18 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 215
   m_MaxRayIntersections: 0
+--- !u!114 &519420034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 11298620df4d80c46b764c9bb2628498, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &525594367
 GameObject:
   m_ObjectHideFlags: 0

--- a/Defend The Divine/Assets/Scripts/ShakeBehavior.cs
+++ b/Defend The Divine/Assets/Scripts/ShakeBehavior.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ShakeBehavior : MonoBehaviour
+{
+    private Transform transform;
+    private float shakeDuration = 0f;
+    private float shakeMagnitude = 0.1f;
+    private float dampingSpeed = 0.995f;
+    Vector3 initialPosition;
+
+    private void Awake()
+    {
+        if (transform == null)
+        {
+            transform = GetComponent<Transform>();
+        }
+    }
+
+    private void OnEnable()
+    {
+        initialPosition = transform.localPosition;
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (shakeDuration > 0f)
+        {
+            transform.localPosition = initialPosition + Random.insideUnitSphere * shakeMagnitude;
+            shakeDuration -= Time.deltaTime;
+            shakeMagnitude *= dampingSpeed;
+        } else
+        {
+            shakeDuration = 0f;
+            shakeMagnitude = 0.1f;
+            transform.localPosition = initialPosition;
+        }
+    }
+
+    public void TriggerShake(float shakeDuration = 0.25f, float shakeMagnitude = 0.1f, float dampingSpeed = 0.995f)
+    {
+        this.shakeDuration = shakeDuration;
+        this.shakeMagnitude = shakeMagnitude;
+        this.dampingSpeed = dampingSpeed;
+    }
+}

--- a/Defend The Divine/Assets/Scripts/ShakeBehavior.cs.meta
+++ b/Defend The Divine/Assets/Scripts/ShakeBehavior.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11298620df4d80c46b764c9bb2628498
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Defend The Divine/Assets/Scripts/Spells/SpellActivate.cs
+++ b/Defend The Divine/Assets/Scripts/Spells/SpellActivate.cs
@@ -24,6 +24,9 @@ public class SpellActivate : MonoBehaviour
 
     public void OnClick(int index)
     {
+        // Trigger camera shake
+        FindFirstObjectByType<ShakeBehavior>().TriggerShake();
+
         switch (index)
         {
             case 0:


### PR DESCRIPTION
Added a ShakeBehavior script to the camera object that has a method, TriggerShake, that accepts the following parameters:
* shakeDuration - default 0.25f
* shakeMagnitude - default 0.1f
* dampingSpeed - default 0.995f

When a spell is activated, the SpellActivate script will search for the ShakeBehavior object and call a TriggerShake with default values.

The TriggerShake method is reusable for any purpose requiring different shake parameters. Just pass in the desired values.

Work done following the tutorial at this link: https://medium.com/nice-things-ios-android-development/basic-2d-screen-shake-in-unity-9c27b56b516