### PR TITLE
Tower Sell & Stats added

### DIFF
--- a/Defend The Divine/Assets/Prefabs/Towers/CannonTower.prefab
+++ b/Defend The Divine/Assets/Prefabs/Towers/CannonTower.prefab
@@ -105,11 +105,12 @@ MonoBehaviour:
   damagingPrefab: {fileID: 474679912698572556, guid: d760f47b006601e43a3027800f6f82b2, type: 3}
   uiPopupPrefab: {fileID: 5480922836673919474, guid: c64acfdfba45b3244a6a8d3fd3ee2e76, type: 3}
   rangePrefab: {fileID: 5404175338507898556, guid: 55cd93df1269c08478f7016ced343dd9, type: 3}
-  upgradeCost: 5
-  maxUpgradeLevel: 4
+  upgradeCost: 25
+  maxUpgradeLevel: 5
   damageUpgradeAmount: 0.5
   rangeUpgradeAmount: 0.5
   attackSpeedUpgradeAmount: 0.01
+  isPopupUIActive: 0
   projectileSpeed: 20
 --- !u!58 &557187313376879698
 CircleCollider2D:

--- a/Defend The Divine/Assets/Prefabs/Towers/PiercingTower.prefab
+++ b/Defend The Divine/Assets/Prefabs/Towers/PiercingTower.prefab
@@ -141,11 +141,12 @@ MonoBehaviour:
   damagingPrefab: {fileID: 474679912698572556, guid: fd7fc8191959b504b8c58dac7eef2f45, type: 3}
   uiPopupPrefab: {fileID: 5480922836673919474, guid: c64acfdfba45b3244a6a8d3fd3ee2e76, type: 3}
   rangePrefab: {fileID: 5404175338507898556, guid: 55cd93df1269c08478f7016ced343dd9, type: 3}
-  upgradeCost: 3
-  maxUpgradeLevel: 4
+  upgradeCost: 35
+  maxUpgradeLevel: 5
   damageUpgradeAmount: 0.5
   rangeUpgradeAmount: 0.5
   attackSpeedUpgradeAmount: 0.05
+  isPopupUIActive: 0
   projectileSpeed: 7
   numEnemiesToDamage: 4
   numEnemiesToDamageUpgradeAmount: 2

--- a/Defend The Divine/Assets/Prefabs/Towers/SwordTower.prefab
+++ b/Defend The Divine/Assets/Prefabs/Towers/SwordTower.prefab
@@ -190,11 +190,12 @@ MonoBehaviour:
   damagingPrefab: {fileID: 6194810038108574417}
   uiPopupPrefab: {fileID: 5480922836673919474, guid: c64acfdfba45b3244a6a8d3fd3ee2e76, type: 3}
   rangePrefab: {fileID: 5404175338507898556, guid: 55cd93df1269c08478f7016ced343dd9, type: 3}
-  upgradeCost: 5
-  maxUpgradeLevel: 4
+  upgradeCost: 30
+  maxUpgradeLevel: 5
   damageUpgradeAmount: 0.5
   rangeUpgradeAmount: 0.1
   attackSpeedUpgradeAmount: 0.05
+  isPopupUIActive: 0
   rotationSpeed: 2500
   swordSpriteRenderer: {fileID: 1443375537974400236}
 --- !u!58 &-8598380634875836332

--- a/Defend The Divine/Assets/Prefabs/UI/InfoPanelPopup.prefab
+++ b/Defend The Divine/Assets/Prefabs/UI/InfoPanelPopup.prefab
@@ -1,5 +1,139 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1376774513900203911
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1291425106071906252}
+  - component: {fileID: 7238666723560803094}
+  - component: {fileID: 24606201888423284}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1291425106071906252
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1376774513900203911}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5943037268671241161}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7238666723560803094
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1376774513900203911}
+  m_CullTransparentMesh: 1
+--- !u!114 &24606201888423284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1376774513900203911}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Sell
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 7.3
+  m_fontSizeBase: 7.3
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1402201053950665822
 GameObject:
   m_ObjectHideFlags: 0
@@ -146,7 +280,7 @@ GameObject:
   - component: {fileID: 4949421879123615719}
   - component: {fileID: 646812625347421857}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: InfoText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -168,8 +302,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.79919, y: 43.3}
-  m_SizeDelta: {x: 54.097, y: 38.948}
+  m_AnchoredPosition: {x: -0.79919, y: 26.8}
+  m_SizeDelta: {x: 75, y: 38.948}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4949421879123615719
 CanvasRenderer:
@@ -199,7 +333,14 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 
+  m_text: 'Demons Killed: 4444
+
+    Damage: 44444444
+
+    Range: 555555
+
+    Level:
+    555'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -226,8 +367,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 9
-  m_fontSizeBase: 9
+  m_fontSize: 8
+  m_fontSizeBase: 8
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -268,7 +409,7 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &2672085930760332687
+--- !u!1 &3441457146616710717
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -276,52 +417,52 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 3985205248187513138}
-  - component: {fileID: 836487512415872404}
-  - component: {fileID: 3011251441295709593}
-  - component: {fileID: 1331312808975529900}
+  - component: {fileID: 5943037268671241161}
+  - component: {fileID: 4426900793904204591}
+  - component: {fileID: 2426766193484340689}
+  - component: {fileID: 1348815426266350193}
   m_Layer: 5
   m_Name: Sell Button
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &3985205248187513138
+  m_IsActive: 1
+--- !u!224 &5943037268671241161
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2672085930760332687}
+  m_GameObject: {fileID: 3441457146616710717}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6269272071653307488}
+  - {fileID: 1291425106071906252}
   m_Father: {fileID: 2153879168440917409}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 15, y: 6.8624}
-  m_SizeDelta: {x: 30, y: 13.7254}
+  m_AnchorMin: {x: 0, y: 0.24000001}
+  m_AnchorMax: {x: 0, y: 0.24000001}
+  m_AnchoredPosition: {x: 41.335, y: -9.700073}
+  m_SizeDelta: {x: 75, y: 23}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &836487512415872404
+--- !u!222 &4426900793904204591
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2672085930760332687}
+  m_GameObject: {fileID: 3441457146616710717}
   m_CullTransparentMesh: 1
---- !u!114 &3011251441295709593
+--- !u!114 &2426766193484340689
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2672085930760332687}
+  m_GameObject: {fileID: 3441457146616710717}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -345,13 +486,13 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &1331312808975529900
+--- !u!114 &1348815426266350193
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2672085930760332687}
+  m_GameObject: {fileID: 3441457146616710717}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
@@ -385,7 +526,7 @@ MonoBehaviour:
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
   m_Interactable: 1
-  m_TargetGraphic: {fileID: 3011251441295709593}
+  m_TargetGraphic: {fileID: 2426766193484340689}
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
@@ -420,15 +561,15 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6262990892899259389}
-  - {fileID: 3985205248187513138}
   - {fileID: 1691520794518597327}
+  - {fileID: 6262990892899259389}
+  - {fileID: 5943037268671241161}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 11.334702, y: 233.89114}
-  m_SizeDelta: {x: 82.6694, y: 137.7823}
+  m_SizeDelta: {x: 82.6694, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7595291607578740814
 CanvasRenderer:
@@ -483,140 +624,10 @@ MonoBehaviour:
   visibleRange: {fileID: 0}
   tower: {fileID: 0}
   upgradeButton: {fileID: 1674182467954177115}
---- !u!1 &5634873599350992749
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6269272071653307488}
-  - component: {fileID: 8787860178266073489}
-  - component: {fileID: 8495167361532645468}
-  m_Layer: 5
-  m_Name: Text (TMP)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6269272071653307488
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5634873599350992749}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3985205248187513138}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &8787860178266073489
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5634873599350992749}
-  m_CullTransparentMesh: 1
---- !u!114 &8495167361532645468
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5634873599350992749}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Sell
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4281479730
-  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 10
-  m_fontSizeBase: 10
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 512
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+  upgradeButtonText: {fileID: 1276692603520706840}
+  sellButton: {fileID: 1348815426266350193}
+  sellButtonText: {fileID: 24606201888423284}
+  infoText: {fileID: 646812625347421857}
 --- !u!1 &5796728480524762654
 GameObject:
   m_ObjectHideFlags: 0
@@ -653,7 +664,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.24000001}
   m_AnchorMax: {x: 0, y: 0.24000001}
-  m_AnchoredPosition: {x: 41.335, y: -5.2}
+  m_AnchoredPosition: {x: 41.335, y: 18.2}
   m_SizeDelta: {x: 75, y: 23}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &763487507127409940

--- a/Defend The Divine/Assets/Scenes/Main Level.unity
+++ b/Defend The Divine/Assets/Scenes/Main Level.unity
@@ -2320,7 +2320,7 @@ MonoBehaviour:
   spell2Button: {fileID: 951848392}
   spell3Button: {fileID: 0}
   FreezeSpellPrefab: {fileID: 8205279509571411624, guid: f71e8f72f4f9b7d40b58e416910a2c76, type: 3}
-  freezeSpellCooldown: 15
+  freezeSpellCooldown: 1
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0

--- a/Defend The Divine/Assets/Scripts/GameManager.cs
+++ b/Defend The Divine/Assets/Scripts/GameManager.cs
@@ -115,7 +115,6 @@ public class GameManager : MonoBehaviour
         tower2Button.interactable = money < towerPlacement.towerType2Prefab.Cost ? false : true;
         tower3Button.interactable = money < towerPlacement.towerType3Prefab.Cost ? false : true;
         spell1Button.interactable = spellActivate.IsFreezeOnCooldown || money < spellActivate.FreezeSpellPrefab.Cost ? false : true;
-        
     }
 
     public bool RemoveEnemy(Enemy enemy) {

--- a/Defend The Divine/Assets/Scripts/Towers/DivinePillar.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/DivinePillar.cs
@@ -1,6 +1,5 @@
 using TMPro;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 public class DivinePillar : MonoBehaviour
 {
@@ -23,10 +22,11 @@ public class DivinePillar : MonoBehaviour
 
     public void TakeDamage(int damage) {
         health -= damage;
-        healthText.text = $"HP: {health}/{maxHealth}";
         if (health <= 0) {
+            health = 0;
             TowerDestroyed();
         }
+        healthText.text = $"HP: {health}/{maxHealth}";
     }
 
     /// <summary>

--- a/Defend The Divine/Assets/Scripts/Towers/PiercingTower.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/PiercingTower.cs
@@ -39,7 +39,7 @@ public class PiercingTower : Tower
     }
 
     public override void Upgrade() {
-        if (upgradeLevel <= maxUpgradeLevel && GameManager.Instance.Money >= upgradeCost) {
+        if (upgradeLevel < maxUpgradeLevel && GameManager.Instance.Money >= upgradeCost) {
             GameManager.Instance.AddMoney(-upgradeCost);
             upgradeLevel++;
 
@@ -48,7 +48,13 @@ public class PiercingTower : Tower
             ATTACK_DELAY -= attackSpeedUpgradeAmount;
             numEnemiesToDamage += numEnemiesToDamageUpgradeAmount;
 
+            if (upgradeLevel % 2 == 0) sellPrice += sellUpgradeIncrement + 1;
+            else sellPrice += sellUpgradeIncrement;
+
             visibleRange.transform.localScale = new Vector3(range * 2, range * 2);
+
+            UpdateUpgradeButtonInteractibility();
+            UpdatePopupUIText();
         }
     }
 }

--- a/Defend The Divine/Assets/Scripts/Towers/PiercingTower.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/PiercingTower.cs
@@ -48,7 +48,7 @@ public class PiercingTower : Tower
             ATTACK_DELAY -= attackSpeedUpgradeAmount;
             numEnemiesToDamage += numEnemiesToDamageUpgradeAmount;
 
-            if (upgradeLevel % 2 == 0) sellPrice += sellUpgradeIncrement + 1;
+            if (upgradeLevel % 2 == 0) sellPrice += (upgradeCost % 2 == 0) ? sellUpgradeIncrement : sellUpgradeIncrement + 1;
             else sellPrice += sellUpgradeIncrement;
 
             visibleRange.transform.localScale = new Vector3(range * 2, range * 2);

--- a/Defend The Divine/Assets/Scripts/Towers/SwordTower.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/SwordTower.cs
@@ -81,7 +81,7 @@ public class SwordTower : Tower
             range += rangeUpgradeAmount;
             ATTACK_DELAY -= attackSpeedUpgradeAmount;
 
-            if (upgradeLevel % 2 == 0) sellPrice += sellUpgradeIncrement + 1;
+            if (upgradeLevel % 2 == 0) sellPrice += (upgradeCost % 2 == 0) ? sellUpgradeIncrement : sellUpgradeIncrement + 1;
             else sellPrice += sellUpgradeIncrement;
 
             visibleRange.transform.localScale = new Vector3(range * 2, range * 2);

--- a/Defend The Divine/Assets/Scripts/Towers/SwordTower.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/SwordTower.cs
@@ -73,7 +73,7 @@ public class SwordTower : Tower
     }
 
     public override void Upgrade() {
-        if (upgradeLevel <= maxUpgradeLevel && GameManager.Instance.Money >= upgradeCost) {
+        if (upgradeLevel < maxUpgradeLevel && GameManager.Instance.Money >= upgradeCost) {
             GameManager.Instance.AddMoney(-upgradeCost);
             upgradeLevel++;
 
@@ -81,8 +81,14 @@ public class SwordTower : Tower
             range += rangeUpgradeAmount;
             ATTACK_DELAY -= attackSpeedUpgradeAmount;
 
+            if (upgradeLevel % 2 == 0) sellPrice += sellUpgradeIncrement + 1;
+            else sellPrice += sellUpgradeIncrement;
+
             visibleRange.transform.localScale = new Vector3(range * 2, range * 2);
             swordSpriteRenderer.transform.localScale = new Vector3(swordSpriteRenderer.transform.localScale.x, range * 1.65f);
+
+            UpdateUpgradeButtonInteractibility();
+            UpdatePopupUIText();
         }
     }
 }

--- a/Defend The Divine/Assets/Scripts/Towers/Tower.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/Tower.cs
@@ -126,8 +126,9 @@ public abstract class Tower : MonoBehaviour, IPointerClickHandler
             range += rangeUpgradeAmount;
             ATTACK_DELAY -= attackSpeedUpgradeAmount;
 
-            if (upgradeLevel % 2 == 0) sellPrice += sellUpgradeIncrement + 1;
+            if (upgradeLevel % 2 == 0) sellPrice += (upgradeCost % 2 == 0) ? sellUpgradeIncrement : sellUpgradeIncrement + 1;
             else sellPrice += sellUpgradeIncrement;
+            
 
             visibleRange.transform.localScale = new Vector3(range * 2, range * 2);
 

--- a/Defend The Divine/Assets/Scripts/Towers/TowerPlacement.cs
+++ b/Defend The Divine/Assets/Scripts/Towers/TowerPlacement.cs
@@ -17,11 +17,6 @@ public class TowerPlacement : MonoBehaviour
     private TowerGhost currentGhostTower;
     private bool canPlaceTower = true;
 
-    private void Awake() {
-        /* REMOVE THIS ONCE ONE CLICK PER TOWER PLACEMENT IS IMPLEMENTED */
-        currentGhostTower = tower1Ghost;
-    }
-
     void Update()
     {
         if (currentTowerPrefab == null || currentGhostTower == null) return;

--- a/Defend The Divine/Assets/Scripts/UI-UX/HandlePanelVisibility.cs
+++ b/Defend The Divine/Assets/Scripts/UI-UX/HandlePanelVisibility.cs
@@ -1,24 +1,29 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
+using TMPro;
 
 public class HandlePanelVisibility : MonoBehaviour, IDeselectHandler, IPointerEnterHandler, IPointerExitHandler
 {
     private bool mouseIsOver = false;
     [HideInInspector] public GameObject visibleRange;
     [HideInInspector] public Tower tower;
-    [SerializeField] Button upgradeButton;
+    public Button upgradeButton;
+    public Button sellButton;
+    public TMP_Text upgradeButtonText;
+    public TMP_Text sellButtonText;
+    public TMP_Text infoText;
 
     private void OnEnable()
     {
         EventSystem.current.SetSelectedGameObject(gameObject);
+        GameManager.Instance.towerPlacement.deselectTower();
     }
 
     private void Start()
     {
         upgradeButton.onClick.AddListener(delegate { tower.Upgrade(); });
+        sellButton.onClick.AddListener(delegate { tower.Sell(visibleRange, gameObject); });
     }
 
 
@@ -27,8 +32,9 @@ public class HandlePanelVisibility : MonoBehaviour, IDeselectHandler, IPointerEn
         //Close the Window on Deselect only if a click occurred outside this panel
         if (!mouseIsOver)
         {
-            gameObject.SetActive(false);
-            visibleRange.SetActive(false);
+            if (gameObject) gameObject.SetActive(false);
+            if (visibleRange) visibleRange.SetActive(false);
+            if (tower) tower.isPopupUIActive = false;
         }
             
     }


### PR DESCRIPTION
Can now sell tower via sell button (it shows u how much money u gain)
Tower sell money is half the cost you spent on it totally
Every upgrade increases it by 50% cost
If you have an odd upgrade cost that's okay, see ex:
EX: Upgrade cost 25, it increases sell value by 12/13/12/13/12/13, etc, alternates. 

Tower popup UI has stats now for range, damage, demons killed, and level.
Upgrade button disabled on max level